### PR TITLE
Add missing header

### DIFF
--- a/cleaner.c
+++ b/cleaner.c
@@ -7,6 +7,7 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <signal.h>
 
 #include "loglib.h"
 #include "memory.h"


### PR DESCRIPTION
Hello!
There was a missing header in _cleaner.c_ (says my compiler).
Otherwise, after a first quick test, the program seems to work well. Very useful tool. Congratulations!
Regards.
Roland

[make.log](https://github.com/emnuppun/C-code-cleaner/files/8096006/make.log)
